### PR TITLE
Queue Group Consumer Test Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,9 @@ TODO:
 
 Tests (explicit) durable queue group consumer. 
 
-The test consists of
-
+The test creates `N` queue subscribers (each with their own connection), then runs the following loop for `M` messages
 ```
-for i in N {
-  setupQueueSubscriber (i)
-}
-
-for j in M {
+for i in M {
   publish (i)
   waitUntilConsume (i)
   verify i

--- a/README.md
+++ b/README.md
@@ -10,9 +10,36 @@ TODO:
 - Add running instructions
 - update dependency list
 - explain folder config
-- create `.gitignore`
 
 # Tests
+
+## `queue-group-consumer`
+
+Tests (explicit) durable queue group consumer. 
+
+The test consists of
+
+```
+for i in N {
+  setupQueueSubscriber (i)
+}
+
+for j in M {
+  publish (i)
+  waitUntilConsume (i)
+  verify i
+  ack (i)
+}
+```
+
+At any given moment, there is only 1 message in-flight and should only be consumed by one subscriber. After a message is published the consumer is expected to receive it before publishing the next message.
+
+The actions of publishing and consuming are resilient to transient failures, meaning they are retried until successful.
+
+The test may fail if:
+- one of the operations is retried unsuccessfully for too long
+- a published message is not consumed within a specified amount of time
+- a previously published message is received out of order 
 
 ## `durable-pull-consumer`
 

--- a/tests/main.go
+++ b/tests/main.go
@@ -3,10 +3,11 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/nats-io/nats.go"
 	"log"
 	"os"
 	"time"
+
+	"github.com/nats-io/nats.go"
 )
 
 var options struct {
@@ -30,6 +31,8 @@ func main() {
 		err = DurablePullConsumerTest()
 	case "kv-cas":
 		err = KVCas()
+	case "queue-pull-consumer":
+		err = QueuePullConsumerTest()
 	default:
 		err = fmt.Errorf("invalid test: '%s'", options.TestName)
 	}

--- a/tests/main.go
+++ b/tests/main.go
@@ -31,7 +31,7 @@ func main() {
 		err = DurablePullConsumerTest()
 	case "kv-cas":
 		err = KVCas()
-	case "queue-pull-consumer":
+	case "queue-group-consumer":
 		err = QueuePullConsumerTest()
 	default:
 		err = fmt.Errorf("invalid test: '%s'", options.TestName)

--- a/tests/queue-group-consumer.go
+++ b/tests/queue-group-consumer.go
@@ -150,11 +150,17 @@ func QueuePullConsumerTest() error {
 	log.Printf("Created %d subscribers to the delivery group\n", SubscriberCount)
 
 	var seqNumber = 1
+	startTime := time.Now()
+
+	log.Printf("Starting test (running for %s or until error)\n", options.TestDuration)
+
+	defer log.Printf("Sent and received %d messages in %s\n", seqNumber-1, time.Since(startTime).Round(1*time.Millisecond))
 
 mainRunLoop:
 	for {
 		select {
 		case <-progressTicker.C:
+			log.Printf("Sent and received %d messages in %s\n", seqNumber-1, time.Since(startTime).Round(1*time.Millisecond))
 			continue mainRunLoop
 		case <-experimentTimer.C:
 			return nil
@@ -196,7 +202,7 @@ mainRunLoop:
 					return fmt.Errorf("Expected %d but received %d by %s", prevSeqNumber, currentData.SeqNumber, currentData.SubscriberID)
 				}
 			case <-experimentTimer.C:
-				return fmt.Errorf("Experiment timed before receiving expected message with sequence number: %d", prevSeqNumber)
+				return nil
 			case <-consumeTimer.C:
 				return fmt.Errorf("Timed out expecting message with sequence number: %d", prevSeqNumber)
 			}

--- a/tests/queue-group-consumer.go
+++ b/tests/queue-group-consumer.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -19,6 +18,7 @@ func QueuePullConsumerTest() error {
 		DefaultRetryTimeout    = 30 * time.Second
 		PublishRetryTimeout    = DefaultRetryTimeout
 		AckRetryTimeout        = DefaultRetryTimeout
+		ConsumeTimeout         = DefaultRetryTimeout
 		RetryDelay             = 1 * time.Second
 		Replicas               = 3
 		ConsumerName           = "ConsumerName"
@@ -27,11 +27,12 @@ func QueuePullConsumerTest() error {
 	)
 
 	type Message struct {
-		SubscriberId string
+		SubscriberID string
 		SeqNumber    int
 	}
 
 	log.Printf("Setting up test")
+
 	nc, err := nats.Connect(
 		options.ServerURL,
 		nats.MaxReconnects(-1),
@@ -97,9 +98,23 @@ func QueuePullConsumerTest() error {
 	experimentTimer := time.NewTimer(options.TestDuration)
 
 	for i := 0; i < SubscriberCount; i++ {
-		subscriberId := fmt.Sprintf("Subscriber-%d", i)
+		subscriberID := fmt.Sprintf("Subscriber-%d", i)
 		go func(id int) {
-			nc.QueueSubscribe(DeliverSubjectName, DeliverGroupName, func(msg *nats.Msg) {
+			nc, err := nats.Connect(
+				options.ServerURL,
+				nats.MaxReconnects(-1),
+				nats.DisconnectErrHandler(func(*nats.Conn, error) {
+					log.Printf("Disconnected")
+				}),
+				nats.ReconnectHandler(func(conn *nats.Conn) {
+					log.Printf("Reconnected")
+				}),
+			)
+			if err != nil {
+				log.Fatalf("failed to connect: %v", err)
+			}
+
+			_, err = nc.QueueSubscribe(DeliverSubjectName, DeliverGroupName, func(msg *nats.Msg) {
 				ackTimer := time.NewTimer(AckRetryTimeout)
 			ackRetryLoop:
 				for {
@@ -121,22 +136,20 @@ func QueuePullConsumerTest() error {
 				}
 
 				var recvMsg Message
-				err = json.Unmarshal(msg.Data, &recvMsg)
-				if err != nil {
-					log.Println("Data format error %w", err)
-				}
-				recvMsg.SubscriberId = subscriberId
+				unmarshalOrPanic(msg.Data, &recvMsg)
+				recvMsg.SubscriberID = subscriberID
 				content <- recvMsg
-				log.Printf("Received #%d by %s", recvMsg.SeqNumber, subscriberId)
+				log.Printf("Received #%d by %s", recvMsg.SeqNumber, subscriberID)
 			})
+
 			if err != nil {
-				log.Fatalln(err)
+				log.Printf("Could not initialize QueueSubscriber-%d %v\n", id, err)
 			}
 		}(i)
 	}
 	log.Printf("Created %d subscribers to the delivery group\n", SubscriberCount)
 
-	var seqNumber int = 1
+	var seqNumber = 1
 
 mainRunLoop:
 	for {
@@ -151,13 +164,10 @@ mainRunLoop:
 		publishRetryLoop:
 			for {
 				msg := nats.NewMsg(StreamSubject)
-				data, err := json.Marshal(&Message{
-					SubscriberId: "",
+				data := marshalOrPanic(&Message{
+					SubscriberID: "",
 					SeqNumber:    seqNumber,
 				})
-				if err != nil {
-					return err
-				}
 				msg.Data = data
 				msg.Subject = StreamSubject
 
@@ -177,11 +187,18 @@ mainRunLoop:
 				}
 			}
 
-			// block until message has been consumed
-			currentData := <-content
+			// block until message has been consumed or a timer has expired
 			prevSeqNumber := seqNumber - 1
-			if currentData.SeqNumber != prevSeqNumber {
-				return fmt.Errorf("Expected %d but received %d by %s\n", prevSeqNumber, currentData.SeqNumber, currentData.SubscriberId)
+			consumeTimer := time.NewTimer(ConsumeTimeout)
+			select {
+			case currentData := <-content:
+				if currentData.SeqNumber != prevSeqNumber {
+					return fmt.Errorf("Expected %d but received %d by %s", prevSeqNumber, currentData.SeqNumber, currentData.SubscriberID)
+				}
+			case <-experimentTimer.C:
+				return fmt.Errorf("Experiment timed before receiving expected message with sequence number: %d", prevSeqNumber)
+			case <-consumeTimer.C:
+				return fmt.Errorf("Timed out expecting message with sequence number: %d", prevSeqNumber)
 			}
 		}
 	}

--- a/tests/queue-pull-consumer.go
+++ b/tests/queue-pull-consumer.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func QueuePullConsumerTest() error {
+	const (
+		DeliverGroupName       = "test-group"
+		DeliverSubjectName     = "test-deliver-subject"
+		StreamName             = "test-stream"
+		StreamSubject          = "test-subject"
+		ProgressUpdateInterval = 3 * time.Second
+		DefaultRetryTimeout    = 30 * time.Second
+		PublishRetryTimeout    = DefaultRetryTimeout
+		AckRetryTimeout        = DefaultRetryTimeout
+		RetryDelay             = 1 * time.Second
+		Replicas               = 3
+		ConsumerName           = "ConsumerName"
+		ConsumerReplicas       = Replicas
+		SubscriberCount        = 10
+	)
+
+	type Message struct {
+		SubscriberId string
+		SeqNumber    int
+	}
+
+	log.Printf("Setting up test")
+	nc, err := nats.Connect(
+		options.ServerURL,
+		nats.MaxReconnects(-1),
+		nats.DisconnectErrHandler(func(*nats.Conn, error) {
+			log.Printf("Disconnected")
+		}),
+		nats.ReconnectHandler(func(conn *nats.Conn) {
+			log.Printf("Reconnected")
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to connect: %w", err)
+	}
+
+	// Create JetStream Context
+	js, err := nc.JetStream()
+	if err != nil {
+		return fmt.Errorf("failed to init JetStream: %w", err)
+	}
+
+	// Create JetStream stream
+	_, err = js.AddStream(&nats.StreamConfig{
+		Name:     StreamName,
+		Subjects: []string{StreamSubject},
+		Replicas: Replicas,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create stream: %w", err)
+	}
+	// Delete stream
+	defer func() {
+		err := js.DeleteStream(StreamName)
+		if err != nil {
+			log.Printf("Could not delete stream %s. %v\n", StreamName, err)
+		}
+	}()
+
+	// Explicit durable queue consumer
+	_, err = js.AddConsumer(
+		StreamName,
+		&nats.ConsumerConfig{
+			Durable:        ConsumerName,
+			DeliverSubject: DeliverSubjectName,
+			DeliverGroup:   DeliverGroupName,
+			AckPolicy:      nats.AckExplicitPolicy,
+			Replicas:       ConsumerReplicas,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create consumer: %w", err)
+	}
+	// Delete consumer
+	defer func() error {
+		err := js.DeleteConsumer(StreamName, ConsumerName)
+		if err != nil {
+			return fmt.Errorf("failed to delete consumer: %w", err)
+		}
+		return nil
+	}()
+
+	content := make(chan Message)
+	progressTicker := time.NewTicker(ProgressUpdateInterval)
+	experimentTimer := time.NewTimer(options.TestDuration)
+
+	for i := 0; i < SubscriberCount; i++ {
+		subscriberId := fmt.Sprintf("Subscriber-%d", i)
+		go func(id int) {
+			nc.QueueSubscribe(DeliverSubjectName, DeliverGroupName, func(msg *nats.Msg) {
+				ackTimer := time.NewTimer(AckRetryTimeout)
+			ackRetryLoop:
+				for {
+					err := msg.AckSync()
+					if err == nil {
+						break ackRetryLoop
+					}
+
+					log.Printf("Ack error: %s", err)
+
+					select {
+					case <-experimentTimer.C:
+						return
+					case <-ackTimer.C:
+						log.Fatalf("timed out trying to ack (last error: %s)", err)
+					case <-time.After(RetryDelay):
+						// Try again
+					}
+				}
+
+				var recvMsg Message
+				err = json.Unmarshal(msg.Data, &recvMsg)
+				if err != nil {
+					log.Println("Data format error %w", err)
+				}
+				recvMsg.SubscriberId = subscriberId
+				content <- recvMsg
+				log.Printf("Received #%d by %s", recvMsg.SeqNumber, subscriberId)
+			})
+			if err != nil {
+				log.Fatalln(err)
+			}
+		}(i)
+	}
+	log.Printf("Created %d subscribers to the delivery group\n", SubscriberCount)
+
+	var seqNumber int = 1
+
+mainRunLoop:
+	for {
+		select {
+		case <-progressTicker.C:
+			continue mainRunLoop
+		case <-experimentTimer.C:
+			return nil
+		default:
+			// publish
+			publishTimer := time.NewTimer(PublishRetryTimeout)
+		publishRetryLoop:
+			for {
+				msg := nats.NewMsg(StreamSubject)
+				data, err := json.Marshal(&Message{
+					SubscriberId: "",
+					SeqNumber:    seqNumber,
+				})
+				if err != nil {
+					return err
+				}
+				msg.Data = data
+				msg.Subject = StreamSubject
+
+				_, err = js.PublishMsg(msg)
+				if err == nil {
+					log.Printf("Published #%d\n", seqNumber)
+					seqNumber++
+					break publishRetryLoop
+				}
+				select {
+				case <-experimentTimer.C:
+					return nil
+				case <-publishTimer.C:
+					return fmt.Errorf("timed out trying to publish %w", err)
+				case <-time.After(RetryDelay):
+					// retry publish
+				}
+			}
+
+			// block until message has been consumed
+			currentData := <-content
+			prevSeqNumber := seqNumber - 1
+			if currentData.SeqNumber != prevSeqNumber {
+				return fmt.Errorf("Expected %d but received %d by %s\n", prevSeqNumber, currentData.SeqNumber, currentData.SubscriberId)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Includes a Queue Push Consumer test client.

Finds an error when running `./rolling-bounce-test.sh`:
```
2023/02/23 20:46:51 Received #20298 by Subscriber-17
2023/02/23 20:46:51 Published #20299
2023/02/23 20:46:51 Received #20299 by Subscriber-22
2023/02/23 20:46:51 Published #20300
2023/02/23 20:46:51 Received #20300 by Subscriber-19
2023/02/23 20:46:51 Published #20301
2023/02/23 20:46:51 Received #8116 by Subscriber-22
2023/02/23 20:46:51 Test failed: Expected 20301 but received 8116 by Subscriber-22
exit status 1
❌ Test failed
```